### PR TITLE
Add PBR dependency

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -43,4 +43,5 @@ Installing ARA from latest release on PyPi
 ------------------------------------------
 ::
 
+    pip install pbr
     pip install ara


### PR DESCRIPTION
pip is unable to auto-resolve the pbr dependency behind a firewall/proxy (it gets others).   Must be installed before ara.   Testing on a base RHEL7 image.