### PR TITLE
Gunicorn support

### DIFF
--- a/ara/wsgi.py
+++ b/ara/wsgi.py
@@ -19,7 +19,8 @@ import os
 
 
 def application(environ, start_response):
-    os.environ['ANSIBLE_CONFIG'] = environ['ANSIBLE_CONFIG']
+    if 'ANSIBLE_CONFIG' in environ:
+        os.environ['ANSIBLE_CONFIG'] = environ['ANSIBLE_CONFIG']
     from ara.webapp import create_app
     app = create_app()
     return app(environ, start_response)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pygments
 debtcollector>=1.2.0
 junit-xml>=1.7
 pyfakefs
+gunicorn
 
 XStatic>=1.0.0 # MIT License
 XStatic-Bootstrap-SCSS>=3.3.7.1 # Apache 2.0 License


### PR DESCRIPTION
I took the trouble of improving your code in order to set Ara project supported by gunicorn. The main reason was the benefits we are getting, supporting a new server and in particular at the time of using containers compared to Apache approach.

Through Apache, env variables are passed through the ```environ``` variable as you set, whereas in gunicorn this environment variables are assigned to ```os.environ``` instead. (using ```gunicorn ... --env ANSIBLE_CONFIG...```).

This case is particular useful when using Openshift Python s2i image, as Openshift takes care about everything and it deploys this automatically.