### PR TITLE
Ubuntu and Debian also depend on setuptools

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -32,7 +32,7 @@ Required dependencies
 
 ::
 
-    apt-get -y install gcc python-dev libffi-dev libssl-dev
+    apt-get -y install gcc python-dev python-setuptools libffi-dev libssl-dev
 
 Development or integration testing dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
error-message without `python-setuptools`:
```# pip install ara
Collecting ara
  Using cached ara-0.13.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
    ImportError: No module named setuptools

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-K_tUSO/ara/
```