### PR TITLE
Work around for PyMySQL warnings 1300

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -181,10 +181,10 @@ Be sure you update your pg_hba.conf afterwards if needed.
 
 Then, setup the database connection::
 
-    export ARA_DATABASE="postgresql+psycopg2://ara:password@localhost:5432/ara"
+    export ARA_DATABASE="postgresql+psycopg2://ara:password@localhost:5432/ara?binary_prefix=true"
     # or
     [ara]
-    database = postgresql+psycopg2://ara:password@localhost:5432/ara
+    database = postgresql+psycopg2://ara:password@localhost:5432/ara?binary_prefix=true
 
 You will need to install the database driver by::
 


### PR DESCRIPTION
Work around to fix warnings "1300 Invalid ..... character string" when using latest version of PyMySQL 
 and MySQL (https://bitbucket.org/zzzeek/sqlalchemy/issues/4216/mysql-specific-binary-warnings-1300)
?binary_prefix=true