### PR TITLE
typo fix, added wheel dependency for debian/ubuntu

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -40,7 +40,7 @@ Development or integration testing dependencies
 ::
 
     apt-get install python-pip libxml2-dev libxslt1-dev
-    pip install tox
+    pip install tox wheel
 
 Installing ARA from trunk source
 --------------------------------
@@ -59,7 +59,7 @@ Installing ARA from latest release on PyPi
 When installing ARA using ``--user``, command line scripts will be installed
 inside ``~/.local/bin`` folder which may not be in ``PATH``. You may want to
 assure that this folder is in PATH or to use the alternative calling method
-``pyhton -m ara`` which calls Ansible module directly.
+``python -m ara`` which calls Ansible module directly.
 
 The alternative calling method has the advantage that allows user to control
 which python interpreter would be used. For example you could install ARA in


### PR DESCRIPTION
While installing at Debian 9 I got error:
```error: invalid command 'bdist_wheel'```
after installing wheel, install goes well